### PR TITLE
Don't break wire:navigate when inert effecting dialogs are open

### DIFF
--- a/js/plugins/navigate/page.js
+++ b/js/plugins/navigate/page.js
@@ -1,7 +1,8 @@
 let oldBodyScriptTagHashes = []
 
 let attributesExemptFromScriptTagHashing = [
-    'data-csrf'
+    'data-csrf',
+    'aria-hidden',
 ]
 
 export function swapCurrentPageWithNewHtml(html, andThen) {
@@ -197,6 +198,9 @@ function ignoreAttributes(subject, attributesToRemove) {
 
         result = result.replace(regex, '')
     })
+
+    // Remove all whitespace to make things less flaky...
+    result = result.replaceAll(' ', '')
 
     return result.trim()
 }


### PR DESCRIPTION
Review the contribution guide first at: https://livewire.laravel.com/docs/contribution-guide

1️⃣ Is this something that is wanted/needed? Did you create a discussion about it first?

2️⃣ Did you create a branch for your fix/feature? (Main branch PR's will be closed)

3️⃣ Does it contain multiple, unrelated changes? Please separate the PRs out.

4️⃣ Does it include tests? (Required)

5️⃣ Please include a thorough description (including small code snippets if possible) of the improvement and reasons why it's useful.

Thanks for contributing! 🙌
